### PR TITLE
react-navigation-stack version updated for iPhone 12 series statusBar…

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "prop-types": "^15.6.2",
     "react-navigation": "^4.x",
     "react-navigation-drawer": "^2.2.1",
-    "react-navigation-stack": "^1.7.3",
+    "react-navigation-stack": "^2.10.0",
     "react-navigation-tabs": "^2.5.2",
     "remove": "^0.1.5"
   },


### PR DESCRIPTION
Scene header is broken on iPhone 12 series because of status-bar height issue. this version update on dependencies/react-navigation-stack will fix it.